### PR TITLE
Removed version number + added extended html chars

### DIFF
--- a/src-docs/overrides/index.html
+++ b/src-docs/overrides/index.html
@@ -73,7 +73,7 @@
 <img src="static/example-screenshot-1.png" />
 <h2>Installation</h2>
 <p>Install ol-kit and its <code>peerDependencies</code></p>
-<code>npm i @bayer/ol-kit ol@4.6.5 react react-dom styled-components @material-ui/core @material-ui/icons @material-ui/styles --save</code>
+<code>npm i @bayer/ol-kit ol react react-dom styled-components @material-ui/core @material-ui/icons @material-ui/styles --save</code>
 <h2>Getting Started</h2>
 <p>It's easy to start building map apps with ol-kit. For simple projects the following will get you started:</p>
 <pre class="prettyprint source lang-javascript"><code>
@@ -105,13 +105,13 @@
   
     render () {
       return (
-        <Map onMapInit={this.onMapInit} fullScreen>
-          <BasemapContainer />
-          <ContextMenu />
-          <Controls />
-          <LayerPanel />
-          <Popup />
-        </Map>
+        &lt;Map onMapInit={this.onMapInit} fullScreen&gt;
+          &lt;BasemapContainer /&gt;
+          &lt;ContextMenu /&gt;
+          &lt;Controls /&gt;
+          &lt;LayerPanel /&gt;
+          &lt;Popup /&gt;
+        &lt;/Map&gt;
       )
     }
   }


### PR DESCRIPTION
Line 76 "ol@4.6.5" to "ol"
Added extended html characters to render function for avoiding treatment as html markup by browser.

Resolves: https://github.com/MonsantoCo/ol-kit/issues/207

### PR Safety Checklist:

 - [ ] Added the task to the appropriate release doc under **Enhancements** or **Bug Fixes**
 - [ ] Bump `package.json` & `package-lock.json` version numbers to appropriate release
 - [ ] (optional) All external API changes have been documented
 - [ ] (optional) Build docs: `npm run docs`

### Quick Description of Changes (+ screenshots for ui changes):
File Changed: https://github.com/MonsantoCo/ol-kit/blob/master/src-docs/overrides/index.html
Line 76 "ol@4.6.5" to "ol"
Added extended html characters to render function for avoiding treatment as html markup by browser.
Failed to run `npm run docs` so that needs to be done for changes to take effect on live docs site
